### PR TITLE
Use least privilege for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -5,6 +5,10 @@ on:
         branches:
             - main
 
+permissions:
+  contents: read
+  pages: write
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Following the security concern of least privilige for GHA runner, allow only read for contents and write for pages.