### PR TITLE
Remove "under construction" notice

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,13 +50,6 @@
     </nav>
     <div class="container mt-5">
         <h1>Intel&reg; Ethernet Linux Driver Repositories</h1>
-        <p>
-            <button type="button" class="btn btn-primary">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-info" viewBox="0 0 16 16">
-                    <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"></path>
-                </svg>
-                2024-July: This page is under construction...
-            </button>
         <p>The following links go to Intel's released driver sources. Feedback on
            issues found or suggestions should be communicated to Intel Product Support or
            can be given via PR or Issue report on the respective pages.</p>


### PR DESCRIPTION
Remove "under construction" notice as all the drivers have been released at GitHub platform.